### PR TITLE
Make fetch-dependencies.sh work in standard OSX

### DIFF
--- a/fetch-dependencies.sh
+++ b/fetch-dependencies.sh
@@ -15,7 +15,7 @@ rm -rf build/
 mkdir -p build
 
 cd build
-wget $SDK_URL
+curl $SDK_URL
 unzip $SDK_FILE
 cd ..
 


### PR DESCRIPTION
Standard OSX installation does not contain `wget` by default, replace it with `curl`